### PR TITLE
Add autoload magic comment

### DIFF
--- a/counsel-fd.el
+++ b/counsel-fd.el
@@ -30,7 +30,7 @@
 (defvar counsel-fd-command "fd --hidden --color never "
   "Base command for fd.")
 
-
+;;;###autoload
 (defun counsel-fd-dired-jump (&optional initial-input initial-directory)
   "Jump to a directory (in dired) below the current directory.
 List all subdirectories within the current directory.
@@ -51,7 +51,7 @@ INITIAL-DIRECTORY, if non-nil, is used as the root directory for search."
               :action (lambda (d) (dired-jump nil (expand-file-name d)))
               :caller 'counsel-fd-dired-jump)))
 
-
+;;;###autoload
 (defun counsel-fd-file-jump (&optional initial-input initial-directory)
   "Jump to a file below the current directory.
 List all files within the current directory or any of its subdirectories.


### PR DESCRIPTION
So far, we need `(require 'counsel-fd)` in our init.el.
This PR makes you not need it and faster.

Package system like pakcage.el, El-Get and more automatically produces a loaddefs.el.
loaddefs.el provides delaying loading lisp functions and loading automatically when the function is called.