### PR TITLE
Look for binary in counsel-fd-command instead of hardcoded fd

### DIFF
--- a/counsel-fd.el
+++ b/counsel-fd.el
@@ -40,7 +40,7 @@ INITIAL-DIRECTORY, if non-nil, is used as the root directory for search."
    (list nil
          (when current-prefix-arg
            (read-directory-name "From directory: "))))
-  (counsel-require-program "fd")
+  (counsel-require-program (car (split-string counsel-fd-command)))
   (let* ((default-directory (or initial-directory default-directory)))
     (ivy-read "Directory: "
               (split-string
@@ -61,7 +61,7 @@ INITIAL-DIRECTORY, if non-nil, is used as the root directory for search."
    (list nil
          (when current-prefix-arg
            (read-directory-name "From directory: "))))
-  (counsel-require-program "fd")
+  (counsel-require-program (car (split-string counsel-fd-command)))
   (let* ((default-directory (or initial-directory default-directory)))
     (ivy-read "File: "
               (split-string


### PR DESCRIPTION
This mr is prompted by the fact that in Ubuntu, the binary is called `fdfind`